### PR TITLE
Solves #73 for figure positioning

### DIFF
--- a/Example_extract_ankle_artic_surf.m
+++ b/Example_extract_ankle_artic_surf.m
@@ -76,7 +76,7 @@ for n_d = 1:numel(dataset_set)
     % GIBOC_tibia.m the exported triangulations can be customized.
     
     % plot the articular surfaces and nearby bone
-    figure('Name', dataset_name, 'Position', [626 502 1175 459])
+    figure('Name', dataset_name, 'Position', get_figpos_artic_surf())
     
     % talocrural art surf on tibial side
     subplot(1,2,1)

--- a/Example_extract_tibiofem_artic_surf.m
+++ b/Example_extract_tibiofem_artic_surf.m
@@ -77,7 +77,7 @@ for n_d = 1:numel(dataset_set)
     % GIBOC_tibia.m the exported triangulations can be customized.
     
     % plot the articular surfaces and nearby bone
-    figure('Name', dataset_name, 'Position', [626 502 1175 459])
+    figure('Name', dataset_name, 'Position', get_figpos_artic_surf())
     
     % distal femur and articular surface of individual condyles
     subplot(1, 2, 1)

--- a/get_figpos_artic_surf.m
+++ b/get_figpos_artic_surf.m
@@ -1,0 +1,21 @@
+function figPos = get_figpos_artic_surf(varargin)
+mp = get(0, 'MonitorPositions'); %gets the monitor position(s)
+
+if size(mp,1) > 1 % if there is more than 1 monitor
+    indMonitor = find(strncmpi(varargin(1:2:end), 'Monitor', 3)); % Monitor argument
+    if ~isempty(indMonitor)
+        % if 'Monitor' argument is passed
+        % positions of the selected monitor
+        mp = mp(cell2mat(varargin(indMonitor(end)+1)),:);
+    else
+        % else the largest screen is selected to plot
+        mp = mp(prod(mp,2) == max(prod(mp,2)), :);
+    end
+end
+
+left = mp(1) + mp(3)/5;    % leftFig = leftMonitor + widthMonitor/5
+bottom = mp(2) + mp(4)/5;  % bottomFig = bottomMonitor + heightMonitor/2
+width = 2*mp(3)/3;         % widthFig = widthMonitor
+height = 2*mp(4)/3;        % heightFig = heightMonitor
+figPos = [left, bottom, width, height];
+end


### PR DESCRIPTION
`get_figpos_artic_surf.m` calculates figure positions either for the selected monitor or for the largest monitor. Example files for the articular surfaces are updated to use the largest monitor for plotting.