### PR TITLE
Fix error relative to orientation in femur_processEpiPhysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ docs/*.m
 tests/models_from_tests/
 *.zip
 /*_safe/
+*ISSUE*/
 
 # openSim files
 *.log

--- a/STAPLE/algorithms/private/GIBOC_femur_processEpiPhysis.m
+++ b/STAPLE/algorithms/private/GIBOC_femur_processEpiPhysis.m
@@ -54,18 +54,14 @@ Axes = EpiFem.Points(IdCdlPts(:,1),:)-EpiFem.Points(IdCdlPts(:,2),:);
 % P = [EpiFem.Points(IdCdlPts(:,1),:);EpiFem.Points(IdCdlPts(:,2),:)];
 % plot3(P(:,1), P(:,2), P(:,3),'-')
 
-I_Axes_duplicate = find(Axes*Axes(round(length(Axes)/2),:)'<0);
+% Remove duplicate Axes that are not directed from Lateral to Medial (CSs.Y0)
+I_Axes_duplicate = find(Axes*CSs.Y0 < 0);
 
-% Delete duplicate but inverted Axes
 IdCdlPts(I_Axes_duplicate,:)=[];
 Axes(I_Axes_duplicate,:)=[];
-U_Axes = Axes./repmat(sqrt(sum(Axes.^2,2)),1,3);
 
-% Are CSs.Y0 and U_Axes pointing in the same direction?
-Orientation = round(mean(sign(U_Axes*CSs.Y0)));
-% Make all the axes point in the Laterat -> Medial direction
-U_Axes = Orientation*U_Axes;
-% Axes = Orientation*Axes;
+%Normalize Axes to get unitary vectors
+U_Axes = Axes./repmat(sqrt(sum(Axes.^2,2)),1,3);
 
 % delete if too far from inertial medio-Lat axis;
 % [LM] 0.75 -> acod(0.75) roughly 41 deg
@@ -77,12 +73,14 @@ U_Axes(ind_deviant_axes,:) = [];
 [ U_Axes_Good] = PCRegionGrowing(U_Axes, normalizeV( mean(U_Axes) )', 0.1);
 LIA = ismember(U_Axes,U_Axes_Good,'rows');
 U_Axes(~LIA,:) = [];
-% Axes(~LIA,:) = [];
 IdCdlPts(~LIA,:) = [];
 
-% Assign indices of points on Lateral or Medial Condyles Variable
+% Compute orientation just to check, should be = 1
+Orientation = round(mean(sign(U_Axes*CSs.Y0)));
 
+% Assign indices of points on Lateral or Medial Condyles Variable
 if Orientation < 0
+    warning('Orientation of Lateral->Medial U_Axes vectors of femoral distal epiphysis is not what expected. Please check manually.')
     med_lat_ind = [2 1];
 %     IdxPtsCondylesLat = IdCdlPts(:,1);
 %     IdxPtsCondylesMed = IdCdlPts(:,2);


### PR DESCRIPTION
The code was made more robust and can no deal with special cases were the majority of  initial U_Axes don't go from one condyle to the other but go from epicondyles to condyles edges. Closes #87 .